### PR TITLE
Bilderanzeige und Speichern einer Analyse ohne Auswahl

### DIFF
--- a/apps/analysis/views.py
+++ b/apps/analysis/views.py
@@ -70,11 +70,17 @@ def index(request, experimentId):
         'experiment_owner_id': expowner_id,
     }
 
-    #Safe all Data from the measurement object into the session storage to get them when applying filter
+    #Safe all Data from the measurement object into the session storage to view old data before the changes
     request.session['measurementData'] = json.dumps(measurement.data, cls=NumPyArangeEncoder)
     request.session['measurementHeader'] = json.dumps(measurement.colNames, cls=NumPyArangeEncoder)
     request.session['measurementUnits'] = json.dumps(measurement.colUnits, cls=NumPyArangeEncoder)
     request.session['measurementTimeIndex'] = json.dumps(measurement.timeIndex, cls=NumPyArangeEncoder)
+
+    # Safe all Data a second time to save changes for a new experiment
+    request.session['measurementDataNew'] = json.dumps(measurement.data, cls=NumPyArangeEncoder)
+    request.session['measurementHeaderNew'] = json.dumps(measurement.colNames, cls=NumPyArangeEncoder)
+    request.session['measurementUnitsNew'] = json.dumps(measurement.colUnits, cls=NumPyArangeEncoder)
+    request.session['measurementTimeIndexNew'] = json.dumps(measurement.timeIndex, cls=NumPyArangeEncoder)
 
 
     return render(request, "analysis/index.html", dataForRender)
@@ -239,7 +245,7 @@ def newESave(request):
         header.append("undefined")
         units.append("undefined")
         measurement_instruments.append("No")
-        
+
     new_experiment = Experiment(project_id=projectId, timerow=time_row, name=experiment_name, description=description)
     new_experiment.save()
     experiment_id = new_experiment.id

--- a/rattler/static/analysis/index.js
+++ b/rattler/static/analysis/index.js
@@ -156,6 +156,7 @@ $('#analyseAuswahlForm').submit(function(event){
             }
         }
         var experimentId = parseInt($("#experimentId").val());
+        console.log("im here");
 
         $.ajax({
 
@@ -237,8 +238,10 @@ $('#analyseAuswahlForm').submit(function(event){
 
             Plotly.newPlot('firstGraph', traces, layout);
         }
-        console.log(dataArray);
+        console.log("im here");
 
 
     }})
+    console.log("im here");
+
 });

--- a/rattler/templates/projects/project_detail.html
+++ b/rattler/templates/projects/project_detail.html
@@ -72,7 +72,7 @@
                 <a style="position:absolute;top:0;right:0;" class="btn white grey-text darken-text-2 imageCarouselNext waves-effect"><i class="material-icons">keyboard_arrow_right</i></a>
             </div>
             {% for image in object.projectimage_set.all %}
-                <a>
+                <a
                     style="display:block;
                             background: url('/{{image.path.url}}') no-repeat center center;
                             background-size: cover;


### PR DESCRIPTION
1. Aufgrund eines Klammersetzungsfehlers wurden die Bilder nicht richtig angezeigt.
2. Wurde bei der Analyse keine Fourriertransformation und kein Filter ausgewählt, wurde ein 
    Fehler angezeigt. Dies wurde gefixt, indem ein measurement_object initialisiert  wird, egal ob 
    bei der Analyse eine Datei verändert wird oder nicht.